### PR TITLE
Duration14 fixes

### DIFF
--- a/AugmentedNet/input_representations.py
+++ b/AugmentedNet/input_representations.py
@@ -109,7 +109,7 @@ class Duration14(FeatureRepresentationTI):
         [0, 1, 1, 1, 1, 1, 1],
     ]
 
-    def run(self):
+    def run(self, transposition=None):
         array = np.zeros(self.shape, dtype=self.dtype)
         prev_measure = -1
         idx = 0

--- a/AugmentedNet/input_representations.py
+++ b/AugmentedNet/input_representations.py
@@ -119,14 +119,14 @@ class Duration14(FeatureRepresentationTI):
                 prev_measure = measure
             pattern = self.pattern[idx]
             array[frame, 0:7] = pattern
-            idx += 1
+            idx = min(idx + 1, len(self.pattern) - 1)
         idx = 0
         for frame, onset in enumerate(self.df.s_isOnset):
             if sum(onset) > 0:
                 idx = 0
             pattern = self.pattern[idx]
             array[frame, 7:] = pattern
-            idx += 1
+            idx = min(idx + 1, len(self.pattern) - 1)
         return array
 
     @classmethod


### PR DESCRIPTION
Providing a couple of fixes to the `Duration14` representation:
- It still can't encode any measure longer than a `longa`, but it will not crash because of it
- Including an unused `transposition` argument to handle data augmentation properly