### PR TITLE
Removing drum parts from music21.stream before processing.

### DIFF
--- a/AugmentedNet/score_parser.py
+++ b/AugmentedNet/score_parser.py
@@ -37,7 +37,14 @@ S_LISTTYPE_COLUMNS = [
 
 
 def _m21Parse(f, fmt=None):
-    return music21.converter.parse(f, format=fmt)
+    s = music21.converter.parse(f, format=fmt)
+    perc = [
+        p
+        for p in s.parts
+        if list(p.recurse().getElementsByClass("PercussionClef"))
+    ]
+    s.remove(perc, recurse=True)
+    return s
 
 
 def from_tsv(tsv, sep="\t"):


### PR DESCRIPTION
Fixes #79 

The chosen strategy was to look for `music21.stream.Part`s with a `PercussionClef` object within and remove them.

This is done only in the `score_parser` because it shouldn't affect annotation files or synthetic examples. Those will never have a percussion track.