### PR TITLE
Adding the fix to texturization patterns for 3/4 and 6/8 meters

### DIFF
--- a/AugmentedNet/score_parser.py
+++ b/AugmentedNet/score_parser.py
@@ -9,6 +9,7 @@ from music21.interval import Interval
 from music21.pitch import Pitch
 from music21.chord import Chord
 from music21.note import Rest
+from music21.meter import TimeSignature
 import numpy as np
 import pandas as pd
 
@@ -144,16 +145,22 @@ def _reindexDataFrame(df, fixedOffset=FIXEDOFFSET):
     return df
 
 
-def _engraveScore(df):
+def _engraveScore(df, timeSignatures=None):
     """Useful for debugging _texturizeAnnotationScore."""
+    tss = timeSignatures or {0.0: "4/4"}
     chords = music21.stream.Stream()
+    offset = 0.0
     for row in df.itertuples():
+        if offset in tss:
+            chords.append(TimeSignature(tss[offset]))
         if row.s_measure == 0:
+            offset += row.s_duration
             continue
         pitches = row.s_notes
         duration = Fraction(row.s_duration).limit_denominator(2048)
         chord = Chord(pitches, quarterLength=duration)
         chords.append(chord)
+        offset += row.s_duration
     return chords
 
 

--- a/AugmentedNet/texturizers.py
+++ b/AugmentedNet/texturizers.py
@@ -6,7 +6,7 @@ import random
 class TextureTemplate(object):
     """The base class for texturization templates."""
 
-    supported_durations = [4.0, 2.0, 1.0]
+    supported_durations = [4.0, 3.0, 2.0, 1.5, 1.0]
     supported_number_of_notes = [3, 4]
 
     def __init__(self, duration, notes, intervals):
@@ -29,9 +29,37 @@ class TextureTemplate(object):
             self.template = self.templateSeventh
 
     def templateTriad(self):
+        if self.duration == 3.0:
+            return self.templateTriadDottedHalf()
+        elif self.duration == 1.5:
+            return self.templateTriadDottedQuarter()
+        else:
+            return self.templateTriadBinary()
+
+    def templateTriadDottedHalf(self):
+        raise NotImplementedError()
+
+    def templateTriadDottedQuarter(self):
+        raise NotImplementedError()
+
+    def templateTriadBinary(self):
         raise NotImplementedError()
 
     def templateSeventh(self):
+        if self.duration == 3.0:
+            return self.templateSeventhDottedHalf()
+        elif self.duration == 1.5:
+            return self.templateSeventhDottedQuarter()
+        else:
+            return self.templateSeventhBinary()
+
+    def templateSeventhDottedHalf(self):
+        raise NotImplementedError()
+
+    def templateSeventhDottedQuarter(self):
+        raise NotImplementedError()
+
+    def templateSeventhBinary(self):
         raise NotImplementedError()
 
     def __str__(self):
@@ -48,18 +76,56 @@ class BassSplit(TextureTemplate):
     the bass note in isolation during the first half,
     followed by the remaining upper notes."""
 
-    def templateTriad(self):
+    def templateTriadBinary(self):
         dur = self.duration / 2
         return f"""\
 0.0,{dur},,['{self.notes[0]}'],[],[True]
 {dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
 """
 
-    def templateSeventh(self):
+    def templateTriadDottedHalf(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+{dur*2},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+{dur*3},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+{dur*4},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+{dur*5},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+"""
+
+    def templateTriadDottedQuarter(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+{dur*2},{dur},,"['{self.notes[1]}', '{self.notes[2]}']",['{self.intervals[2]}'],"[True, True]"
+"""
+
+    def templateSeventhBinary(self):
         dur = self.duration / 2
         return f"""\
 0.0,{dur},,['{self.notes[0]}'],[],[True]
 {dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+"""
+
+    def templateSeventhDottedHalf(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+{dur*2},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+{dur*3},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+{dur*4},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+{dur*5},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+"""
+
+    def templateSeventhDottedQuarter(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
+{dur*2},{dur},,"['{self.notes[1]}', '{self.notes[2]}', '{self.notes[3]}']","['{self.intervals[3]}', '{self.intervals[4]}']","[True, True, True]"
 """
 
 
@@ -69,7 +135,7 @@ class Alberti(TextureTemplate):
     A  4-note  melodic  pattern with the contour
     lowest, highest, middle, highest."""
 
-    def templateTriad(self):
+    def templateTriadBinary(self):
         dur = self.duration / 4
         return f"""\
 0.0,{dur},,['{self.notes[0]}'],[],[True]
@@ -78,13 +144,51 @@ class Alberti(TextureTemplate):
 {dur*3},{dur},,['{self.notes[2]}'],[],[True]
 """
 
-    def templateSeventh(self):
+    def templateTriadDottedHalf(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,['{self.notes[2]}'],[],[True]
+{dur*2},{dur},,['{self.notes[1]}'],[],[True]
+{dur*3},{dur},,['{self.notes[2]}'],[],[True]
+{dur*4},{dur},,['{self.notes[1]}'],[],[True]
+{dur*5},{dur},,['{self.notes[2]}'],[],[True]
+"""
+
+    def templateTriadDottedQuarter(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,['{self.notes[2]}'],[],[True]
+{dur*2},{dur},,['{self.notes[1]}'],[],[True]
+"""
+
+    def templateSeventhBinary(self):
         dur = self.duration / 4
         return f"""\
 0.0,{dur},,['{self.notes[0]}'],[],[True]
 {dur},{dur},,['{self.notes[3]}'],[],[True]
 {dur*2},{dur},,['{self.notes[1]}'],[],[True]
 {dur*3},{dur},,['{self.notes[2]}'],[],[True]
+"""
+
+    def templateSeventhDottedHalf(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,['{self.notes[0]}'],[],[True]
+{dur},{dur},,['{self.notes[3]}'],[],[True]
+{dur*2},{dur},,['{self.notes[1]}'],[],[True]
+{dur*3},{dur},,['{self.notes[2]}'],[],[True]
+{dur*4},{dur},,['{self.notes[1]}'],[],[True]
+{dur*5},{dur},,['{self.notes[2]}'],[],[True]
+"""
+
+    def templateSeventhDottedQuarter(self):
+        dur = 0.5
+        return f"""\
+0.0,{dur},,"['{self.notes[0]}', '{self.notes[3]}']",['{self.intervals[2]}'],[True]
+{dur},{dur},,['{self.notes[1]}'],[],[True]
+{dur*2},{dur},,['{self.notes[2]}'],[],[True]
 """
 
 

--- a/test/auxiliary_files/score_parser/texturizedHaydnOp20No4i.krn
+++ b/test/auxiliary_files/score_parser/texturizedHaydnOp20No4i.krn
@@ -1,123 +1,165 @@
+!!!COM: Music21
+!!!OTL: Music21 Fragment
 **kern
 *clefG2
 *k[]
-*M4/4
+*M3/4
 =1
 2.a 2.cc 2.ee
-[4a [4cc [4ee
 =2
-2a] 2cc] 2ee]
-[2dd#X [2ff [2aa [2ccc
+8aL
+8ccJ 8ee
+8ccL 8ee
+8ccJ 8ee
+8ccL 8ee
+8ccJ 8ee
 =3
-4dd#] 4ff] 4aa] 4ccc]
 2.dd#X 2.ff 2.aa 2.ccc
 =4
+2.dd#X 2.ff 2.aa 2.ccc
+=5
 8bb
 4ee
 8gg#X
-4dd#X 4ff#X 4aa
-[4ee [4gg# [4bb
-=5
-4ee] 4gg#] 4bb]
-8ddnL
-8eeJ 8gg#X 8bb
-[2cc#X [2ee [2aa
-=6
-4cc#] 4ee] 4aa]
-2.ee 2.gg#X 2.bb
-=7
-16aLL
-16ee
-16cc#X
-16eeJJ
-8ddL
+8dd#XL
 8ff#XJ 8aa
-4dd#X 4ff# 4aa
-[4ee [4gg#X [4bb
-=8
-2ee] 2gg#] 2bb]
-[2a [2cc#X [2ee
-=9
-4a] 4cc#] 4ee]
-2.b 2.dd 2.ff#X
-=10
-8bb
-4dd 4ee 4gg#X
-8dd 8ee 8gg#
-4cc#X 4ee 4aa
-8eeL
-8dddJ
-=11
-8gg#XL
-8bbJ
-16aLL
+=6
+4ee
+4gg#X 4bb
+16ddnLL
+16bb
 16ee
-16cc#X
-16eeJJ
-8bbL
-16ddL
 16gg#JJ
-16eeLL
-16gg#J
-8ddJ 8ee 8gg#
-=12
-16cc#XLL
-16aa
-16ee
-16aaJJ
-2ee 2gg#X 2bb 2ddd
-4a 4cc# 4ee
-=13
-2.dd 2.ff#X 2.aa 2.bb
-[4dd [4ee [4gg#X [4bb
-=14
-2dd] 2ee] 2gg#] 2bb]
-[2cc#X [2ee [2aa
-=15
-4cc#] 4ee] 4aa]
-2.dd 2.ff#X 2.aa
-=16
-2.dd 2.ff#X 2.bb
-[4cc#X [4ee [4aa
-=17
-2cc#] 2ee] 2aa]
-[2cc#X [2ee [2aa
-=18
-4cc#] 4ee] 4aa]
-2.cc#X 2.ee 2.aa
-=19
-2.b 2.dd 2.ee 2.gg#X
-[4b [4dd [4ee [4gg#
-=20
-2b] 2dd] 2ee] 2gg#]
-[2cc#X [2ee [2aa
-=21
-4cc#] 4ee] 4aa]
+=7
 8cc#XL
 8aaJ
 8eeL
 8aaJ
-16cc#LL
-16aa
+8eeL
+8aaJ
+!!linebreak:original
+=8
+8eeL
+8bbJ
+8gg#XL
+8bbJ
+8gg#L
+8bbJ
+=9
+16aLL
 16ee
-16aaJJ
-=22
-8gg#X
-4b 4dd 4ee
-8b 8dd 8ee
+16cc#X
+16eeJJ
+4dd 4ff#X 4aa
+4dd#X 4ff# 4aa
+=10
+2.ee 2.gg#X 2.bb
+=11
 8aL
-8cc#XJ 8ee
-8bbL
-[8ddJ
-=23
-8ddL]
+8eeJ
+8cc#XL
+8eeJ
+8cc#L
+8eeJ
+=12
+8bL
 8ff#XJ
-16eeLL
+8ddL
+8ff#J
+8ddL
+8ff#J
+=13
+2dd 2ee 2gg#X 2bb
+4cc#X 4ee 4aa
+!!linebreak:original
+=14
+4ee
+16gg#XLL
 16ddd
-16gg#X
-16bbJJ
-[2a [2cc#X [2ee
+16bb
+16dddJJ
+4a 4cc#X 4ee
+=15
+8bbL
+16ddL
+16gg#XJJ
+16eeLL
+16gg#J
+8ddJ 8ee 8gg#
+8cc#XL
+8eeJ 8aa
+=16
+2ee 2gg#X 2bb 2ddd
+4a 4cc#X 4ee
+=17
+2.dd 2.ff#X 2.aa 2.bb
+=18
+8ddL
+8bbJ
+8eeL
+8gg#XJ
+8eeL
+8gg#J
+=19
+8cc#XL
+8aaJ
+8eeL
+8aaJ
+8eeL
+8aaJ
+=20
+2.dd 2.ff#X 2.aa
+!!linebreak:original
+=21
+8ddL
+8ff#XJ 8bb
+8ff#L 8bb
+8ff#J 8bb
+8ff#L 8bb
+8ff#J 8bb
+=22
+2.cc#X 2.ee 2.aa
+=23
+8cc#XL
+8aaJ
+8eeL
+8aaJ
+8eeL
+8aaJ
 =24
-4a] 4cc#] 4ee]
+8cc#XL
+8eeJ 8aa
+8eeL 8aa
+8eeJ 8aa
+8eeL 8aa
+8eeJ 8aa
+=25
+2.b 2.dd 2.ee 2.gg#X
+=26
+2.b 2.dd 2.ee 2.gg#X
+=27
+8cc#XL
+8aaJ
+8eeL
+8aaJ
+8eeL
+8aaJ
+!!linebreak:original
+=28
+8aa
+4cc#X
+8ee
+8cc#L
+8eeJ 8aa
+=29
+2b 2dd 2ee 2gg#X
+4a 4cc#X 4ee
+=30
+4dd
+4ff#X 4bb
+8eeL
+8gg#XJ 8bb 8ddd
+=31
+2.a 2.cc#X 2.ee
 ==
 *-

--- a/test/test_score_parser.py
+++ b/test/test_score_parser.py
@@ -58,7 +58,8 @@ class TestScoreParser(unittest.TestCase):
         )
         # This test is somewhat cheating, but I prefer the higher coverage
         # render the df into a m21 score, then compare scores (gt, generated)
-        s = score_parser._engraveScore(df)
+        timeSignatures = {0.0: "3/4"}
+        s = score_parser._engraveScore(df, timeSignatures)
         s = s.makeNotation()
         gt = music21.converter.parse(
             aux.texturizedHaydnOp20No4i, format="humdrum"

--- a/test/test_texturizers.py
+++ b/test/test_texturizers.py
@@ -68,7 +68,7 @@ class TestTexturizers(unittest.TestCase):
         self.assertEqual(available_number_of_notes, GT)
 
     def test_available_durations(self):
-        GT = [4.0, 2.0, 1.0]
+        GT = [4.0, 3.0, 2.0, 1.5, 1.0]
         self.assertEqual(available_durations, GT)
 
     def test_available_templates(self):


### PR DESCRIPTION
Fixes #87.

The implementations are based on the existing patterns.

The `dotted half` is particularly tricky, because it may be a full measure in `3/4` or a full measure in `6/8`, but those have two very different accentuation patterns. Thus, alberti is 

```
L H M H M H 
```

always in eighth notes; bass split is

```
L MH MH MH MH MH
```

always in eighth notes as well

The simplest compromise I could find